### PR TITLE
Add candlestick websocket handlers

### DIFF
--- a/backend/services/websocketService.js
+++ b/backend/services/websocketService.js
@@ -1,9 +1,23 @@
 // backend/services/websocketService.js
 const socketIo = require('socket.io');
+const createExchangeService = require('./ExchangeService');
+const createMarketDataService = require('./marketDataService');
+
+const INTERVAL_MS = {
+  '1m': 60 * 1000,
+  '5m': 5 * 60 * 1000,
+  '15m': 15 * 60 * 1000,
+  '1h': 60 * 60 * 1000,
+  '4h': 4 * 60 * 60 * 1000,
+  '1d': 24 * 60 * 60 * 1000,
+};
 
 class WebSocketService {
   constructor() {
     this.io = null;
+    this.candlestickIntervals = {};
+    const exchangeService = createExchangeService();
+    this.marketDataService = createMarketDataService(exchangeService);
     console.log('[BE WS] WebSocketService constructor called');
     this.generateFakeMarketData = () => {
       const pairs = ['BTC/KRW', 'ETH/KRW'];
@@ -48,13 +62,50 @@ class WebSocketService {
         socket.on('disconnect', (reason) => {
           console.log(`[BE WS] 클라이언트 연결 해제: ${socket.id}, 이유: ${reason}`);
         });
-        socket.on('subscribe', (channel) => {
+        socket.on('getCandles', async ({ symbol, interval }) => {
+          try {
+            const intervalMs = INTERVAL_MS[interval] || INTERVAL_MS['1m'];
+            const endTime = Date.now();
+            const startTime = endTime - intervalMs * 50;
+            const candles = await this.marketDataService.getCandlestickData(
+              symbol,
+              interval,
+              startTime,
+              endTime
+            );
+            socket.emit('candles', candles);
+          } catch (err) {
+            console.error('[BE WS] getCandles error:', err);
+            socket.emit('candles', []);
+          }
+        });
+
+        socket.on('subscribe', (payload) => {
+          const channel = typeof payload === 'string' ? payload : payload.channel;
+          if (!channel) return;
           console.log(`[BE WS] 클라이언트 ${socket.id}가 ${channel} 구독 요청`);
           socket.join(channel);
+
+          const parsed = this._parseCandlestickChannel(channel);
+          if (parsed && !this.candlestickIntervals[channel]) {
+            this._startCandlestickUpdates(channel, parsed.symbol, parsed.interval);
+          }
         });
-        socket.on('unsubscribe', (channel) => {
+
+        socket.on('unsubscribe', (payload) => {
+          const channel = typeof payload === 'string' ? payload : payload.channel;
+          if (!channel) return;
           console.log(`[BE WS] 클라이언트 ${socket.id}가 ${channel} 구독 해지 요청`);
           socket.leave(channel);
+
+          const room = this.io.sockets.adapter.rooms.get(channel);
+          if (!room) {
+            const parsed = this._parseCandlestickChannel(channel);
+            if (parsed && this.candlestickIntervals[channel]) {
+              clearInterval(this.candlestickIntervals[channel]);
+              delete this.candlestickIntervals[channel];
+            }
+          }
         });
         socket.on('error', (error) => {
             console.error(`[BE WS] 소켓 오류 (ID: ${socket.id}):`, error);
@@ -77,6 +128,32 @@ class WebSocketService {
       this.io = null;
       throw error;
     }
+  }
+
+  _parseCandlestickChannel(channel) {
+    const match = /^candlestick:(.+):([^:]+)$/.exec(channel);
+    if (!match) return null;
+    return { symbol: match[1], interval: match[2] };
+  }
+
+  _startCandlestickUpdates(channel, symbol, interval) {
+    const intervalMs = INTERVAL_MS[interval] || INTERVAL_MS['1m'];
+    this.candlestickIntervals[channel] = setInterval(async () => {
+      try {
+        const endTime = Date.now();
+        const startTime = endTime - intervalMs;
+        const data = await this.marketDataService.getCandlestickData(
+          symbol,
+          interval,
+          startTime,
+          endTime
+        );
+        const candle = data[data.length - 1];
+        this.io.to(channel).emit('candlestick', candle);
+      } catch (err) {
+        console.error('[BE WS] candlestick update error:', err);
+      }
+    }, intervalMs);
   }
 }
 


### PR DESCRIPTION
## Summary
- extend websocket service with candlestick support
- add `getCandles` listener to return historical data
- handle `subscribe` and `unsubscribe` for candlestick channels
- broadcast new candle updates on subscribed channels

## Testing
- `npm run test:unit` *(fails: jest not found)*