### PR TITLE
Update start frontend script

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "test:unit": "jest",
     "eject": "react-scripts eject",
     "server": "node server.js",
-    "start:frontend": "NODE_OPTIONS='--openssl-legacy-provider' PORT=3002 craco start",
+    "start:frontend": "NODE_OPTIONS=--openssl-legacy-provider PORT=3002 craco start",
     "start:backend": "PORT=3035 node backend/server.js",
     "dev": "concurrently \"npm run start:frontend\" \"npm run start:backend\""
   },


### PR DESCRIPTION
## Summary
- update `start:frontend` script to use NODE_OPTIONS without quotes
- attempted to run `npm install` and `npm run dev`, but `concurrently` was missing

## Testing
- `npm run dev` *(fails: concurrently not found)*