### PR TITLE
Add DepthChart component for orderbook depth

### DIFF
--- a/src/components/OrderBook/DepthChart.css
+++ b/src/components/OrderBook/DepthChart.css
@@ -1,0 +1,21 @@
+.depth-chart {
+  width: 100%;
+  height: 150px;
+}
+
+.depth-chart svg {
+  width: 100%;
+  height: 100%;
+}
+
+.bids-area {
+  fill: rgba(0, 81, 199, 0.3);
+  stroke: #0051c7;
+  stroke-width: 2;
+}
+
+.asks-area {
+  fill: rgba(214, 0, 0, 0.3);
+  stroke: #d60000;
+  stroke-width: 2;
+}

--- a/src/components/OrderBook/DepthChart.js
+++ b/src/components/OrderBook/DepthChart.js
@@ -1,0 +1,92 @@
+import React, { useEffect, useState, useRef } from 'react';
+import webSocketService from '../../services/websocketService';
+import './DepthChart.css';
+
+const DepthChart = ({ symbol }) => {
+  const [depth, setDepth] = useState({ bids: [], asks: [] });
+  const containerRef = useRef(null);
+  const [dimensions, setDimensions] = useState({ width: 300, height: 150 });
+
+  useEffect(() => {
+    const updateDimensions = () => {
+      if (containerRef.current) {
+        setDimensions({
+          width: containerRef.current.clientWidth,
+          height: containerRef.current.clientHeight,
+        });
+      }
+    };
+    updateDimensions();
+    window.addEventListener('resize', updateDimensions);
+    return () => window.removeEventListener('resize', updateDimensions);
+  }, []);
+
+  useEffect(() => {
+    const handleUpdate = (data) => {
+      if (data && data.symbol === symbol) {
+        setDepth(data);
+      }
+    };
+    webSocketService.on('orderbook-update', handleUpdate);
+    webSocketService.emit('subscribe', { channel: `market-${symbol}` });
+    return () => {
+      webSocketService.off('orderbook-update', handleUpdate);
+      webSocketService.emit('unsubscribe', { channel: `market-${symbol}` });
+    };
+  }, [symbol]);
+
+  const computeDepth = (orders, isBid) => {
+    const sorted = [...orders].sort((a, b) =>
+      isBid ? b.price - a.price : a.price - b.price
+    );
+    let cumulative = 0;
+    return sorted.map((o) => {
+      const qty = parseFloat(o.quantity || o.amount || 0);
+      cumulative += qty;
+      return { price: parseFloat(o.price), cumulative };
+    });
+  };
+
+  const bids = computeDepth(depth.bids || [], true);
+  const asks = computeDepth(depth.asks || [], false);
+
+  const allPrices = [...bids.map((b) => b.price), ...asks.map((a) => a.price)];
+  const minPrice = Math.min(...allPrices);
+  const maxPrice = Math.max(...allPrices);
+  const maxVolume = Math.max(
+    bids[bids.length - 1]?.cumulative || 0,
+    asks[asks.length - 1]?.cumulative || 0
+  );
+
+  const scaleX = (price) =>
+    ((price - minPrice) / (maxPrice - minPrice || 1)) * dimensions.width;
+  const scaleY = (vol) =>
+    dimensions.height - (vol / (maxVolume || 1)) * dimensions.height;
+
+  const createPath = (data) => {
+    if (!data.length) return '';
+    let path = `M ${scaleX(data[0].price)} ${scaleY(data[0].cumulative)}`;
+    for (let i = 1; i < data.length; i++) {
+      path += ` L ${scaleX(data[i].price)} ${scaleY(data[i].cumulative)}`;
+    }
+    const last = data[data.length - 1];
+    path += ` L ${scaleX(last.price)} ${dimensions.height}`;
+    path += ` L ${scaleX(data[0].price)} ${dimensions.height} Z`;
+    return path;
+  };
+
+  return (
+    <div className="depth-chart" ref={containerRef}>
+      <svg
+        width={dimensions.width}
+        height={dimensions.height}
+        viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+      >
+        <path d={createPath(bids)} className="bids-area" />
+        <path d={createPath(asks)} className="asks-area" />
+      </svg>
+    </div>
+  );
+};
+
+export default DepthChart;

--- a/src/components/OrderBook/OrderBook.js
+++ b/src/components/OrderBook/OrderBook.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import './OrderBook.css';
+import DepthChart from './DepthChart';
 
 const OrderBook = ({ data, symbol }) => {
   const [orderBookData, setOrderBookData] = useState({
@@ -251,6 +252,7 @@ const OrderBook = ({ data, symbol }) => {
           </div>
         </div>
       </div>
+      <DepthChart symbol={symbol} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- implement `DepthChart` component for visualising order book depth
- add related CSS styles
- integrate `DepthChart` into `OrderBook`

## Testing
- `npm test` *(fails: craco not found)*
- `npm run test:unit` *(fails: jest not found)*