### PR TITLE
Add external market APIs

### DIFF
--- a/backend/controllers/marketController.js
+++ b/backend/controllers/marketController.js
@@ -1,0 +1,58 @@
+const externalApiService = require('../services/ExternalApiService');
+
+/**
+ * @swagger
+ * /api/markets:
+ *   get:
+ *     summary: Get default market tickers from Binance and Upbit
+ *     responses:
+ *       200:
+ *         description: Market data
+ */
+exports.getMarkets = async (req, res) => {
+  try {
+    const data = await externalApiService.getDefaultMarkets();
+    res.json(data);
+  } catch (err) {
+    console.error('getMarkets error:', err);
+    res.status(500).json({ message: 'Failed to fetch markets' });
+  }
+};
+
+/**
+ * @swagger
+ * /api/markets/{exchange}/{symbol}:
+ *   get:
+ *     summary: Get ticker data from a specific exchange
+ *     parameters:
+ *       - in: path
+ *         name: exchange
+ *         schema:
+ *           type: string
+ *         required: true
+ *       - in: path
+ *         name: symbol
+ *         schema:
+ *           type: string
+ *         required: true
+ *     responses:
+ *       200:
+ *         description: Ticker information
+ */
+exports.getTicker = async (req, res) => {
+  const { exchange, symbol } = req.params;
+  try {
+    let data;
+    if (exchange === 'binance') {
+      data = await externalApiService.fetchBinanceTicker(symbol);
+    } else if (exchange === 'upbit') {
+      data = await externalApiService.fetchUpbitTicker(symbol);
+    } else {
+      return res.status(400).json({ message: 'Unsupported exchange' });
+    }
+    res.json(data);
+  } catch (err) {
+    console.error('getTicker error:', err);
+    res.status(500).json({ message: 'Failed to fetch ticker' });
+  }
+};

--- a/backend/routes/marketRoutes.js
+++ b/backend/routes/marketRoutes.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const router = express.Router();
+const marketController = require('../controllers/marketController');
+
+/**
+ * @swagger
+ * /api/markets:
+ *   get:
+ *     summary: Retrieve default market tickers
+ *   /api/markets/{exchange}/{symbol}:
+ *     get:
+ *       summary: Retrieve ticker from specific exchange
+ */
+
+router.get('/', marketController.getMarkets);
+router.get('/:exchange/:symbol', marketController.getTicker);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -59,6 +59,7 @@ const walletRoutes = require('./routes/walletRoutes');
 const authRoutes = require('./routes/authRoutes');
 const tradeRoutes = require('./routes/tradeRoutes');
 const portfolioRoutes = require('./routes/portfolioRoutes');
+const marketRoutes = require('./routes/marketRoutes');
 const websocketService = require('./services/websocketService');
 
 app.use('/api/v1', walletRoutes);
@@ -66,6 +67,7 @@ app.use('/api/auth', authRoutes);  // /api/auth 경로로 수정
 app.use('/auth', authRoutes);      // 기존 /auth 경로도 유지
 app.use('/api/orders', tradeRoutes);
 app.use('/api/portfolio', portfolioRoutes);
+app.use('/api/markets', marketRoutes);
 
 // WebSocket 초기화
 websocketService.initWebSocket(server);

--- a/backend/services/ExternalApiService.js
+++ b/backend/services/ExternalApiService.js
@@ -1,0 +1,38 @@
+const axios = require('axios');
+
+class ExternalApiService {
+  constructor() {
+    this.cache = {};
+    this.ttl = 10000; // 10 seconds
+  }
+
+  // Generic get with caching
+  async _cachedRequest(key, url) {
+    const now = Date.now();
+    if (this.cache[key] && now - this.cache[key].timestamp < this.ttl) {
+      return this.cache[key].data;
+    }
+    const response = await axios.get(url);
+    this.cache[key] = { data: response.data, timestamp: now };
+    return response.data;
+  }
+
+  async fetchBinanceTicker(symbol) {
+    const url = `https://api.binance.com/api/v3/ticker/24hr?symbol=${symbol}`;
+    return this._cachedRequest(`binance_${symbol}`, url);
+  }
+
+  async fetchUpbitTicker(symbol) {
+    const url = `https://api.upbit.com/v1/ticker?markets=${symbol}`;
+    const data = await this._cachedRequest(`upbit_${symbol}`, url);
+    return Array.isArray(data) ? data[0] : data;
+  }
+
+  async getDefaultMarkets() {
+    const binance = await this.fetchBinanceTicker('BTCUSDT');
+    const upbit = await this.fetchUpbitTicker('KRW-BTC');
+    return { binance, upbit };
+  }
+}
+
+module.exports = new ExternalApiService();

--- a/server.js
+++ b/server.js
@@ -33,12 +33,14 @@ db.sequelize.authenticate()
 const walletRoutes = require('./backend/routes/walletRoutes');
 const authRoutes = require('./backend/routes/authRoutes');
 const tradeRoutes = require('./backend/routes/tradeRoutes');
+const marketRoutes = require('./backend/routes/marketRoutes');
 const websocketService = require('./backend/services/websocketService');
 
 app.use('/api/v1', walletRoutes);
 app.use('/api/auth', authRoutes);  // /api/auth 경로로 수정
 app.use('/auth', authRoutes);      // 기존 /auth 경로도 유지
 app.use('/api/orders', tradeRoutes);
+app.use('/api/markets', marketRoutes);
 
 websocketService.initWebSocket(server);
 


### PR DESCRIPTION
## Summary
- add ExternalApiService with Binance and Upbit requests
- expose market endpoints via new controller and routes
- mount /api/markets in both server entrypoints
- document new endpoints with Swagger comments

## Testing
- `npm test` *(fails: craco not found)*