### PR TITLE
Add responsive media queries for layout and header

### DIFF
--- a/src/components/layout/Header.css
+++ b/src/components/layout/Header.css
@@ -31,3 +31,28 @@
   cursor: pointer;
   font-size: 18px;
 }
+
+/* Responsive design */
+@media (max-width: 1024px) {
+  .header {
+    padding: 0 15px;
+  }
+
+  .header-left {
+    gap: 15px;
+  }
+}
+
+@media (max-width: 768px) {
+  .header {
+    padding: 0 10px;
+  }
+
+  .header-left {
+    gap: 10px;
+  }
+
+  .header-right {
+    gap: 5px;
+  }
+}

--- a/src/components/layout/TradingLayout.css
+++ b/src/components/layout/TradingLayout.css
@@ -698,6 +698,12 @@
       grid-template-columns: 240px 1fr 320px;
     }
   }
+
+  @media (max-width: 1024px) {
+    .trading-grid {
+      grid-template-columns: 220px 1fr 280px;
+    }
+  }
   
   @media (max-width: 768px) {
     .trading-grid {


### PR DESCRIPTION
## Summary
- add 1024px breakpoint for trading grid
- make header responsive with 1024px and 768px queries

## Testing
- `npm test` *(fails: craco not found)*