### PR TITLE
Implement theme persistence and light style

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,6 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import webSocketServiceInstance from './services/websocketService'; // WebSocket 서비스
 import { AuthProvider } from './contexts/AuthContext'; // 인증 컨텍스트
 import { OrderProvider } from './contexts/OrderContext'; // 주문 컨텍스트 import 확인!
-import { ThemeProvider } from './contexts/ThemeContext';
 import { MarketProvider } from './contexts/MarketContext';
 
 // 페이지 및 레이아웃 컴포넌트 import
@@ -43,7 +42,6 @@ function App() {
   }, []);
 
   return (
-    <ThemeProvider>
       <AuthProvider>
         <MarketProvider>
           <OrderProvider>
@@ -72,3 +70,7 @@ function App() {
           </OrderProvider>
         </MarketProvider>
       </AuthProvider>
+  );
+}
+
+export default App;

--- a/src/contexts/ThemeContext.js
+++ b/src/contexts/ThemeContext.js
@@ -3,15 +3,22 @@ import React, { createContext, useContext, useState, useEffect } from 'react';
 const ThemeContext = createContext(null);
 
 export const ThemeProvider = ({ children }) => {
-  const [theme, setTheme] = useState('light');
+  const [theme, setTheme] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('theme') || 'dark';
+    }
+    return 'dark';
+  });
 
   const toggleTheme = () => {
     setTheme(prevTheme => prevTheme === 'light' ? 'dark' : 'light');
   };
 
   useEffect(() => {
-    document.body.classList.remove('light', 'dark');
-    document.body.classList.add(theme);
+    const root = document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+    localStorage.setItem('theme', theme);
   }, [theme]);
 
   const value = {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,13 @@
 @import './variables.css';
 
+:root {
+  color-scheme: dark;
+}
+
+.light :root {
+  color-scheme: light;
+}
+
 * {
   margin: 0;
   padding: 0;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -11,3 +11,17 @@
   --hover-overlay: rgba(255, 255, 255, 0.05);
   --font-family-base: 'Noto Sans KR', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
+
+.light :root {
+  --bg-primary: #ffffff;
+  --bg-secondary: #f5f5f5;
+  --bg-tertiary: #e5e5e5;
+  --text-primary: #000000;
+  --text-secondary: #4a4a4a;
+  --border-color: #cccccc;
+  --accent-color: #1b9cfc;
+  --buy-color: #1261e4;
+  --sell-color: #d9304e;
+  --hover-overlay: rgba(0, 0, 0, 0.05);
+  --font-family-base: 'Noto Sans KR', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}


### PR DESCRIPTION
## Summary
- persist theme preference in `ThemeContext`
- add light theme variables and apply them
- support color-scheme switching in global CSS
- wrap app with `ThemeProvider` only once

## Testing
- `npm run test:unit` *(fails: jest not found)*
- `npm test` *(fails: craco not found)*