### PR TITLE
Add Coin and Pair management API

### DIFF
--- a/backend/controllers/admin/coinController.js
+++ b/backend/controllers/admin/coinController.js
@@ -1,0 +1,56 @@
+const { Coin } = require('../../models');
+
+exports.listCoins = async (req, res) => {
+  try {
+    const coins = await Coin.findAll({ order: [['id', 'ASC']] });
+    res.json(coins);
+  } catch (err) {
+    console.error('[coinController] listCoins error:', err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+exports.getCoin = async (req, res) => {
+  try {
+    const coin = await Coin.findByPk(req.params.id);
+    if (!coin) return res.status(404).json({ message: 'Not found' });
+    res.json(coin);
+  } catch (err) {
+    console.error('[coinController] getCoin error:', err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+exports.createCoin = async (req, res) => {
+  try {
+    const coin = await Coin.create(req.body);
+    res.status(201).json(coin);
+  } catch (err) {
+    console.error('[coinController] createCoin error:', err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+exports.updateCoin = async (req, res) => {
+  try {
+    const { id, ...data } = req.body;
+    const [updated] = await Coin.update(data, { where: { id } });
+    if (!updated) return res.status(404).json({ message: 'Not found' });
+    const coin = await Coin.findByPk(id);
+    res.json(coin);
+  } catch (err) {
+    console.error('[coinController] updateCoin error:', err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+exports.deleteCoin = async (req, res) => {
+  try {
+    const deleted = await Coin.destroy({ where: { id: req.params.id } });
+    if (!deleted) return res.status(404).json({ message: 'Not found' });
+    res.json({ success: true });
+  } catch (err) {
+    console.error('[coinController] deleteCoin error:', err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};

--- a/backend/controllers/admin/pairController.js
+++ b/backend/controllers/admin/pairController.js
@@ -1,0 +1,56 @@
+const { Pair } = require('../../models');
+
+exports.listPairs = async (req, res) => {
+  try {
+    const pairs = await Pair.findAll({ order: [['id', 'ASC']] });
+    res.json(pairs);
+  } catch (err) {
+    console.error('[pairController] listPairs error:', err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+exports.getPair = async (req, res) => {
+  try {
+    const pair = await Pair.findByPk(req.params.id);
+    if (!pair) return res.status(404).json({ message: 'Not found' });
+    res.json(pair);
+  } catch (err) {
+    console.error('[pairController] getPair error:', err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+exports.createPair = async (req, res) => {
+  try {
+    const pair = await Pair.create(req.body);
+    res.status(201).json(pair);
+  } catch (err) {
+    console.error('[pairController] createPair error:', err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+exports.updatePair = async (req, res) => {
+  try {
+    const { id, ...data } = req.body;
+    const [updated] = await Pair.update(data, { where: { id } });
+    if (!updated) return res.status(404).json({ message: 'Not found' });
+    const pair = await Pair.findByPk(id);
+    res.json(pair);
+  } catch (err) {
+    console.error('[pairController] updatePair error:', err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+exports.deletePair = async (req, res) => {
+  try {
+    const deleted = await Pair.destroy({ where: { id: req.params.id } });
+    if (!deleted) return res.status(404).json({ message: 'Not found' });
+    res.json({ success: true });
+  } catch (err) {
+    console.error('[pairController] deletePair error:', err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};

--- a/backend/migrations/20250516060000-create-coin-and-pair.js
+++ b/backend/migrations/20250516060000-create-coin-and-pair.js
@@ -1,0 +1,30 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('coins', {
+      id: { type: Sequelize.BIGINT, primaryKey: true, autoIncrement: true },
+      symbol: { type: Sequelize.STRING(10), allowNull: false, unique: true },
+      name: { type: Sequelize.STRING(50), allowNull: false },
+      decimals: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 8 },
+      active: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: true },
+      created_at: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updated_at: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') }
+    });
+
+    await queryInterface.createTable('pairs', {
+      id: { type: Sequelize.BIGINT, primaryKey: true, autoIncrement: true },
+      base: { type: Sequelize.STRING(10), allowNull: false },
+      quote: { type: Sequelize.STRING(10), allowNull: false },
+      fee: { type: Sequelize.DECIMAL(10,4), allowNull: false, defaultValue: 0 },
+      active: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: true },
+      created_at: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updated_at: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') }
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('pairs');
+    await queryInterface.dropTable('coins');
+  }
+};

--- a/backend/models/Coin.js
+++ b/backend/models/Coin.js
@@ -1,0 +1,16 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const Coin = sequelize.define('Coin', {
+    id: { type: DataTypes.BIGINT, primaryKey: true, autoIncrement: true },
+    symbol: { type: DataTypes.STRING(10), allowNull: false, unique: true },
+    name: { type: DataTypes.STRING(50), allowNull: false },
+    decimals: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 8 },
+    active: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true }
+  }, {
+    tableName: 'coins',
+    timestamps: true,
+    createdAt: 'created_at',
+    updatedAt: 'updated_at'
+  });
+  return Coin;
+};

--- a/backend/models/Pair.js
+++ b/backend/models/Pair.js
@@ -1,0 +1,16 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const Pair = sequelize.define('Pair', {
+    id: { type: DataTypes.BIGINT, primaryKey: true, autoIncrement: true },
+    base: { type: DataTypes.STRING(10), allowNull: false },
+    quote: { type: DataTypes.STRING(10), allowNull: false },
+    fee: { type: DataTypes.DECIMAL(10,4), allowNull: false, defaultValue: 0 },
+    active: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true }
+  }, {
+    tableName: 'pairs',
+    timestamps: true,
+    createdAt: 'created_at',
+    updatedAt: 'updated_at'
+  });
+  return Pair;
+};

--- a/backend/routes/adminCoinRoutes.js
+++ b/backend/routes/adminCoinRoutes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const coinController = require('../controllers/admin/coinController');
+
+router.get('/', coinController.listCoins);
+router.get('/:id', coinController.getCoin);
+router.post('/', coinController.createCoin);
+router.put('/', coinController.updateCoin);
+router.delete('/:id', coinController.deleteCoin);
+
+module.exports = router;

--- a/backend/routes/adminPairRoutes.js
+++ b/backend/routes/adminPairRoutes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const pairController = require('../controllers/admin/pairController');
+
+router.get('/', pairController.listPairs);
+router.get('/:id', pairController.getPair);
+router.post('/', pairController.createPair);
+router.put('/', pairController.updatePair);
+router.delete('/:id', pairController.deletePair);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -63,6 +63,8 @@ const authRoutes = require('./routes/authRoutes');
 const tradeRoutes = require('./routes/tradeRoutes');
 const portfolioRoutes = require('./routes/portfolioRoutes');
 const marketRoutes = require('./routes/marketRoutes');
+const adminCoinRoutes = require('./routes/adminCoinRoutes');
+const adminPairRoutes = require('./routes/adminPairRoutes');
 const websocketService = require('./services/websocketService');
 
 app.use('/api/v1', walletRoutes);
@@ -71,6 +73,8 @@ app.use('/auth', authRoutes);      // 기존 /auth 경로도 유지
 app.use('/api/orders', tradeRoutes);
 app.use('/api/portfolio', portfolioRoutes);
 app.use('/api/markets', marketRoutes);
+app.use('/api/admin/coins', adminCoinRoutes);
+app.use('/api/admin/pairs', adminPairRoutes);
 
 // WebSocket 초기화
 websocketService.initWebSocket(server);

--- a/server.js
+++ b/server.js
@@ -34,6 +34,8 @@ const walletRoutes = require('./backend/routes/walletRoutes');
 const authRoutes = require('./backend/routes/authRoutes');
 const tradeRoutes = require('./backend/routes/tradeRoutes');
 const marketRoutes = require('./backend/routes/marketRoutes');
+const adminCoinRoutes = require('./backend/routes/adminCoinRoutes');
+const adminPairRoutes = require('./backend/routes/adminPairRoutes');
 const websocketService = require('./backend/services/websocketService');
 
 app.use('/api/v1', walletRoutes);
@@ -41,6 +43,8 @@ app.use('/api/auth', authRoutes);  // /api/auth 경로로 수정
 app.use('/auth', authRoutes);      // 기존 /auth 경로도 유지
 app.use('/api/orders', tradeRoutes);
 app.use('/api/markets', marketRoutes);
+app.use('/api/admin/coins', adminCoinRoutes);
+app.use('/api/admin/pairs', adminPairRoutes);
 
 websocketService.initWebSocket(server);
 


### PR DESCRIPTION
## Summary
- add Coin and Pair Sequelize models
- create migration for new tables
- implement admin controllers for CRUD
- register admin routes for coins and pairs
- mount new routes in both servers

## Testing
- `npm test` *(fails: craco not found)*