### PR TITLE
Add stop-loss and take-profit options to orders

### DIFF
--- a/src/components/TradingPanel/OrderTypes/LimitOrder.js
+++ b/src/components/TradingPanel/OrderTypes/LimitOrder.js
@@ -1,13 +1,40 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { validateQuantity, validatePrice } from '../../../utils/validation';
 import Button from '../../common/Button';
 import '../../OrderForm/OrderForm.css';
+import { getAssetSummary } from '../../../services/PortfolioService';
 
 export default function LimitOrder({ symbol, onSubmit }) {
   const [side, setSide] = useState('BUY');
   const [quantity, setQuantity] = useState('');
   const [price, setPrice] = useState('');
   const [error, setError] = useState('');
+  const [balance, setBalance] = useState(0);
+  const [useStopLoss, setUseStopLoss] = useState(false);
+  const [stopLoss, setStopLoss] = useState('');
+  const [useTakeProfit, setUseTakeProfit] = useState(false);
+  const [takeProfit, setTakeProfit] = useState('');
+
+  useEffect(() => {
+    const fetchBalance = async () => {
+      try {
+        const summary = await getAssetSummary();
+        if (summary && typeof summary.available === 'number') {
+          setBalance(summary.available);
+        }
+      } catch (err) {
+        console.error('Failed to fetch balance', err);
+      }
+    };
+    fetchBalance();
+  }, []);
+
+  const handleMax = () => {
+    const priceNum = parseFloat(price);
+    if (!isNaN(priceNum) && priceNum > 0) {
+      setQuantity((balance / priceNum).toString());
+    }
+  };
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -17,11 +44,29 @@ export default function LimitOrder({ symbol, onSubmit }) {
       const priceNum = parseFloat(price);
       validateQuantity(symbol, quantityNum);
       validatePrice(symbol, priceNum);
+      if (useStopLoss && stopLoss) {
+        validatePrice(symbol, parseFloat(stopLoss));
+      }
+      if (useTakeProfit && takeProfit) {
+        validatePrice(symbol, parseFloat(takeProfit));
+      }
       if (onSubmit) {
-        onSubmit({ type: 'LIMIT', side, symbol, quantity: quantityNum, price: priceNum });
+        onSubmit({
+          type: 'LIMIT',
+          side,
+          symbol,
+          quantity: quantityNum,
+          price: priceNum,
+          stopLoss: useStopLoss ? parseFloat(stopLoss) : undefined,
+          takeProfit: useTakeProfit ? parseFloat(takeProfit) : undefined,
+        });
       }
       setQuantity('');
       setPrice('');
+      setStopLoss('');
+      setTakeProfit('');
+      setUseStopLoss(false);
+      setUseTakeProfit(false);
     } catch (err) {
       setError(err.message);
     }
@@ -50,14 +95,18 @@ export default function LimitOrder({ symbol, onSubmit }) {
         </div>
         <div className="form-group">
           <label>수량</label>
-          <input
-            type="number"
-            value={quantity}
-            onChange={(e) => setQuantity(e.target.value)}
-            placeholder="주문 수량"
-            step="any"
-            required
-          />
+          <div style={{ display: 'flex', gap: '5px' }}>
+            <input
+              type="number"
+              value={quantity}
+              onChange={(e) => setQuantity(e.target.value)}
+              placeholder="주문 수량"
+              step="any"
+              required
+              style={{ flex: 1 }}
+            />
+            <button type="button" onClick={handleMax}>MAX</button>
+          </div>
         </div>
         <div className="form-group">
           <label>가격</label>
@@ -69,6 +118,47 @@ export default function LimitOrder({ symbol, onSubmit }) {
             step="any"
             required
           />
+        </div>
+        <div className="form-group">
+          <label>
+            <input
+              type="checkbox"
+              checked={useStopLoss}
+              onChange={() => setUseStopLoss(!useStopLoss)}
+            />
+            {' '}스탑로스
+          </label>
+          {useStopLoss && (
+            <input
+              type="number"
+              value={stopLoss}
+              onChange={(e) => setStopLoss(e.target.value)}
+              placeholder="Stop-Loss 가격"
+              step="any"
+            />
+          )}
+        </div>
+        <div className="form-group">
+          <label>
+            <input
+              type="checkbox"
+              checked={useTakeProfit}
+              onChange={() => setUseTakeProfit(!useTakeProfit)}
+            />
+            {' '}테이크프로핏
+          </label>
+          {useTakeProfit && (
+            <input
+              type="number"
+              value={takeProfit}
+              onChange={(e) => setTakeProfit(e.target.value)}
+              placeholder="Take-Profit 가격"
+              step="any"
+            />
+          )}
+        </div>
+        <div className="form-group">
+          <span>사용 가능 잔고: {balance}</span>
         </div>
         {error && <div className="error-message">{error}</div>}
         <Button type="submit" variant={side === 'BUY' ? 'buy' : 'sell'} className="submit-button">

--- a/src/components/TradingPanel/OrderTypes/MarketOrder.js
+++ b/src/components/TradingPanel/OrderTypes/MarketOrder.js
@@ -1,12 +1,36 @@
-import React, { useState } from 'react';
-import { validateQuantity } from '../../../utils/validation';
+import React, { useState, useEffect } from 'react';
+import { validateQuantity, validatePrice } from '../../../utils/validation';
 import Button from '../../common/Button';
 import '../../OrderForm/OrderForm.css';
+import { getAssetSummary } from '../../../services/PortfolioService';
 
 export default function MarketOrder({ symbol, onSubmit }) {
   const [side, setSide] = useState('BUY');
   const [quantity, setQuantity] = useState('');
   const [error, setError] = useState('');
+  const [balance, setBalance] = useState(0);
+  const [useStopLoss, setUseStopLoss] = useState(false);
+  const [stopLoss, setStopLoss] = useState('');
+  const [useTakeProfit, setUseTakeProfit] = useState(false);
+  const [takeProfit, setTakeProfit] = useState('');
+
+  useEffect(() => {
+    const fetchBalance = async () => {
+      try {
+        const summary = await getAssetSummary();
+        if (summary && typeof summary.available === 'number') {
+          setBalance(summary.available);
+        }
+      } catch (err) {
+        console.error('Failed to fetch balance', err);
+      }
+    };
+    fetchBalance();
+  }, []);
+
+  const handleMax = () => {
+    setQuantity(balance.toString());
+  };
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -14,10 +38,27 @@ export default function MarketOrder({ symbol, onSubmit }) {
     try {
       const quantityNum = parseFloat(quantity);
       validateQuantity(symbol, quantityNum);
+      if (useStopLoss && stopLoss) {
+        validatePrice(symbol, parseFloat(stopLoss));
+      }
+      if (useTakeProfit && takeProfit) {
+        validatePrice(symbol, parseFloat(takeProfit));
+      }
       if (onSubmit) {
-        onSubmit({ type: 'MARKET', side, symbol, quantity: quantityNum });
+        onSubmit({
+          type: 'MARKET',
+          side,
+          symbol,
+          quantity: quantityNum,
+          stopLoss: useStopLoss ? parseFloat(stopLoss) : undefined,
+          takeProfit: useTakeProfit ? parseFloat(takeProfit) : undefined,
+        });
       }
       setQuantity('');
+      setStopLoss('');
+      setTakeProfit('');
+      setUseStopLoss(false);
+      setUseTakeProfit(false);
     } catch (err) {
       setError(err.message);
     }
@@ -46,14 +87,59 @@ export default function MarketOrder({ symbol, onSubmit }) {
         </div>
         <div className="form-group">
           <label>수량</label>
-          <input
-            type="number"
-            value={quantity}
-            onChange={(e) => setQuantity(e.target.value)}
-            placeholder="주문 수량"
-            step="any"
-            required
-          />
+          <div style={{ display: 'flex', gap: '5px' }}>
+            <input
+              type="number"
+              value={quantity}
+              onChange={(e) => setQuantity(e.target.value)}
+              placeholder="주문 수량"
+              step="any"
+              required
+              style={{ flex: 1 }}
+            />
+            <button type="button" onClick={handleMax}>MAX</button>
+          </div>
+        </div>
+        <div className="form-group">
+          <label>
+            <input
+              type="checkbox"
+              checked={useStopLoss}
+              onChange={() => setUseStopLoss(!useStopLoss)}
+            />
+            {' '}스탑로스
+          </label>
+          {useStopLoss && (
+            <input
+              type="number"
+              value={stopLoss}
+              onChange={(e) => setStopLoss(e.target.value)}
+              placeholder="Stop-Loss 가격"
+              step="any"
+            />
+          )}
+        </div>
+        <div className="form-group">
+          <label>
+            <input
+              type="checkbox"
+              checked={useTakeProfit}
+              onChange={() => setUseTakeProfit(!useTakeProfit)}
+            />
+            {' '}테이크프로핏
+          </label>
+          {useTakeProfit && (
+            <input
+              type="number"
+              value={takeProfit}
+              onChange={(e) => setTakeProfit(e.target.value)}
+              placeholder="Take-Profit 가격"
+              step="any"
+            />
+          )}
+        </div>
+        <div className="form-group">
+          <span>사용 가능 잔고: {balance}</span>
         </div>
         {error && <div className="error-message">{error}</div>}
         <Button type="submit" variant={side === 'BUY' ? 'buy' : 'sell'} className="submit-button">


### PR DESCRIPTION
## Summary
- extend `LimitOrder` and `MarketOrder` with optional stop-loss and take-profit inputs
- fetch available balance on mount
- add MAX button to fill quantity with maximum purchasable amount
- include stop-loss and take-profit values in `onSubmit`

## Testing
- `npm run test:unit` *(fails: jest not found)*