### PR TITLE
Enable price selection in trading panel

### DIFF
--- a/src/components/OrderBook/OrderBook.js
+++ b/src/components/OrderBook/OrderBook.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import './OrderBook.css';
 import DepthChart from './DepthChart';
 
-const OrderBook = ({ data, symbol }) => {
+const OrderBook = ({ data, symbol, onPriceSelect }) => {
   const [orderBookData, setOrderBookData] = useState({
     asks: [], // 매도 주문
     bids: [], // 매수 주문
@@ -201,8 +201,11 @@ const OrderBook = ({ data, symbol }) => {
           </div>
           <div className="orderbook-table-body">
             {orderBookData.asks.map((ask, index) => (
-              <div className="orderbook-row" key={`ask-${index}`}>
-                <div className={`col price ${getPriceColor(ask.price, index, true)}`}>
+              <div className="orderbook-row" key={`ask-${index}`}> 
+                <div
+                  className={`col price ${getPriceColor(ask.price, index, true)}`}
+                  onClick={() => onPriceSelect && onPriceSelect(parseFloat(ask.price))}
+                >
                   {formatPrice(ask.price)}
                 </div>
                 <div className="col amount">{parseFloat(ask.amount).toFixed(6)}</div>
@@ -238,7 +241,10 @@ const OrderBook = ({ data, symbol }) => {
           <div className="orderbook-table-body">
             {orderBookData.bids.map((bid, index) => (
               <div className="orderbook-row" key={`bid-${index}`}>
-                <div className={`col price ${getPriceColor(bid.price, index, false)}`}>
+                <div
+                  className={`col price ${getPriceColor(bid.price, index, false)}`}
+                  onClick={() => onPriceSelect && onPriceSelect(parseFloat(bid.price))}
+                >
                   {formatPrice(bid.price)}
                 </div>
                 <div className="col amount">{parseFloat(bid.amount).toFixed(6)}</div>

--- a/src/components/OrderBook/OrderBook.jsx
+++ b/src/components/OrderBook/OrderBook.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import './OrderBook.css';
 import DepthChart from './DepthChart';
 
-const OrderBook = ({ data, symbol }) => {
+const OrderBook = ({ data, symbol, onPriceSelect }) => {
   const [orderBookData, setOrderBookData] = useState({
     asks: [], // 매도 주문
     bids: [], // 매수 주문
@@ -202,7 +202,10 @@ const OrderBook = ({ data, symbol }) => {
           <div className="orderbook-table-body">
             {orderBookData.asks.map((ask, index) => (
               <div className="orderbook-row" key={`ask-${index}`}>
-                <div className={`col price ${getPriceColor(ask.price, index, true)}`}>
+                <div
+                  className={`col price ${getPriceColor(ask.price, index, true)}`}
+                  onClick={() => onPriceSelect && onPriceSelect(parseFloat(ask.price))}
+                >
                   {formatPrice(ask.price)}
                 </div>
                 <div className="col amount">{parseFloat(ask.amount).toFixed(6)}</div>
@@ -238,7 +241,10 @@ const OrderBook = ({ data, symbol }) => {
           <div className="orderbook-table-body">
             {orderBookData.bids.map((bid, index) => (
               <div className="orderbook-row" key={`bid-${index}`}>
-                <div className={`col price ${getPriceColor(bid.price, index, false)}`}>
+                <div
+                  className={`col price ${getPriceColor(bid.price, index, false)}`}
+                  onClick={() => onPriceSelect && onPriceSelect(parseFloat(bid.price))}
+                >
                   {formatPrice(bid.price)}
                 </div>
                 <div className="col amount">{parseFloat(bid.amount).toFixed(6)}</div>

--- a/src/components/TradingPanel/OrderTypes/LimitOrder.js
+++ b/src/components/TradingPanel/OrderTypes/LimitOrder.js
@@ -1,13 +1,19 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { validateQuantity, validatePrice } from '../../../utils/validation';
 import Button from '../../common/Button';
 import '../../OrderForm/OrderForm.css';
 
-export default function LimitOrder({ symbol, onSubmit }) {
+export default function LimitOrder({ symbol, selectedPrice, onSubmit }) {
   const [side, setSide] = useState('BUY');
   const [quantity, setQuantity] = useState('');
   const [price, setPrice] = useState('');
   const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (selectedPrice !== null && selectedPrice !== undefined) {
+      setPrice(selectedPrice);
+    }
+  }, [selectedPrice]);
 
   const handleSubmit = (e) => {
     e.preventDefault();

--- a/src/components/TradingPanel/TradingPanel.js
+++ b/src/components/TradingPanel/TradingPanel.js
@@ -3,7 +3,7 @@ import LimitOrder from './OrderTypes/LimitOrder';
 import MarketOrder from './OrderTypes/MarketOrder';
 import './TradingPanel.css';
 
-export default function TradingPanel({ symbol }) {
+export default function TradingPanel({ symbol, selectedPrice }) {
   const [orderType, setOrderType] = useState('LIMIT');
 
   const handleOrderSubmit = (order) => {
@@ -29,7 +29,7 @@ export default function TradingPanel({ symbol }) {
         </button>
       </div>
       {orderType === 'LIMIT' ? (
-        <LimitOrder symbol={symbol} onSubmit={handleOrderSubmit} />
+        <LimitOrder symbol={symbol} selectedPrice={selectedPrice} onSubmit={handleOrderSubmit} />
       ) : (
         <MarketOrder symbol={symbol} onSubmit={handleOrderSubmit} />
       )}

--- a/src/components/TradingView/TradingView.js
+++ b/src/components/TradingView/TradingView.js
@@ -25,6 +25,7 @@ const TradingView = () => {
     ma60: false,
     ma120: false
   });
+  const [selectedPrice, setSelectedPrice] = useState(null);
   
   // 선택된 심볼에 대한 시장 정보 가져오기
   useEffect(() => {
@@ -220,7 +221,7 @@ const TradingView = () => {
                 </div>
               </div>
               <div className="sidebar">
-                <TradingPanel symbol={activeSymbol} />
+                <TradingPanel symbol={activeSymbol} selectedPrice={selectedPrice} />
               </div>
             </div>
           </div>
@@ -229,10 +230,10 @@ const TradingView = () => {
         {activeTab === 'orderbook' && (
           <div className="orderbook-trade-layout">
             <div className="orderbook-container">
-              <OrderBook symbol={activeSymbol} />
+              <OrderBook symbol={activeSymbol} onPriceSelect={setSelectedPrice} />
             </div>
             <div className="tradepanel-container">
-              <TradingPanel symbol={activeSymbol} />
+              <TradingPanel symbol={activeSymbol} selectedPrice={selectedPrice} />
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- add `onPriceSelect` callback to `OrderBook` and trigger it on price cell click
- track `selectedPrice` in `TradingView` and forward it to `TradingPanel`
- update `TradingPanel` and `LimitOrder` to use the selected price

## Testing
- `npm test` *(fails: craco not found)*