### PR TITLE
Fix dev script to run frontend and backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "browserify-zlib": "^0.2.0",
     "buffer": "^6.0.3",
     "concurrently": "^8.2.2",
+    "cross-env": "^7.0.3",
     "http-proxy-middleware": "^3.0.5",
     "jest": "^29.7.0",
     "nodemon": "^3.1.10",
@@ -67,8 +68,8 @@
     "test:unit": "jest",
     "eject": "react-scripts eject",
     "server": "node server.js",
-    "start:frontend": "NODE_OPTIONS=--openssl-legacy-provider PORT=3000 craco start",
-    "start:backend": "PORT=3035 node backend/server.js",
+    "start:frontend": "cross-env NODE_OPTIONS=--openssl-legacy-provider PORT=3000 craco start",
+    "start:backend": "cross-env PORT=3035 node backend/server.js",
     "dev": "concurrently \"npm run start:frontend\" \"npm run start:backend\""
   },
   "eslintConfig": {


### PR DESCRIPTION
## Summary
- add `cross-env` to dev dependencies for cross-platform env vars
- update start scripts to use `cross-env`

## Testing
- `npm test` *(fails: craco not found)*
- `npm run dev` *(fails: concurrently not found)*