### PR TITLE
Add Sequelize seeders and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ If the backend is not running, the React frontend will encounter WebSocket and A
 The backend uses **MySQL** with Sequelize. Configure credentials via environment variables (`DB_USER`, `DB_PASS`, `DB_NAME`, `DB_HOST`) or edit `mysqlconnect.ini`.
 Start MySQL before running the backend.
 
+After running the database migrations you can seed some demo data:
+
+```bash
+npm run seed
+```
+
 ### Frontend
 Run `npm run start:frontend` to start the React app.
 

--- a/backend/seeders/20250601000000-demo-coins.js
+++ b/backend/seeders/20250601000000-demo-coins.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('coins', [
+      { id: 1, symbol: 'BTC', name: 'Bitcoin', decimals: 8, active: true, created_at: new Date(), updated_at: new Date() },
+      { id: 2, symbol: 'ETH', name: 'Ethereum', decimals: 18, active: true, created_at: new Date(), updated_at: new Date() },
+      { id: 3, symbol: 'USDT', name: 'Tether', decimals: 6, active: true, created_at: new Date(), updated_at: new Date() },
+      { id: 4, symbol: 'KRW', name: 'Korean Won', decimals: 0, active: true, created_at: new Date(), updated_at: new Date() }
+    ], {});
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('coins', null, {});
+  }
+};

--- a/backend/seeders/20250601000001-demo-pairs.js
+++ b/backend/seeders/20250601000001-demo-pairs.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('pairs', [
+      { id: 1, base: 'BTC', quote: 'USDT', fee: 0.001, active: true, created_at: new Date(), updated_at: new Date() },
+      { id: 2, base: 'ETH', quote: 'USDT', fee: 0.001, active: true, created_at: new Date(), updated_at: new Date() },
+      { id: 3, base: 'BTC', quote: 'KRW', fee: 0.001, active: true, created_at: new Date(), updated_at: new Date() }
+    ], {});
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('pairs', null, {});
+  }
+};

--- a/backend/seeders/20250601000002-demo-users.js
+++ b/backend/seeders/20250601000002-demo-users.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('users', [
+      { id: 1, username: 'alice', email: 'alice@example.com', password: '$2b$10$uka0HHb2HCMVmYC17uMQreyn7THGLZ0sXANkI3UrIVKDbVL3qn6ii', created_at: new Date(), updated_at: new Date() },
+      { id: 2, username: 'bob', email: 'bob@example.com', password: '$2b$10$uka0HHb2HCMVmYC17uMQreyn7THGLZ0sXANkI3UrIVKDbVL3qn6ii', created_at: new Date(), updated_at: new Date() }
+    ], {});
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('users', null, {});
+  }
+};

--- a/backend/seeders/20250601000003-demo-wallets.js
+++ b/backend/seeders/20250601000003-demo-wallets.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('wallets', [
+      { id: 1, user_id: 1, coin_symbol: 'BTC', address: 'alice_btc_addr', private_key: 'alice_btc_pk', created_at: new Date() },
+      { id: 2, user_id: 1, coin_symbol: 'USDT', address: 'alice_usdt_addr', private_key: 'alice_usdt_pk', created_at: new Date() },
+      { id: 3, user_id: 2, coin_symbol: 'BTC', address: 'bob_btc_addr', private_key: 'bob_btc_pk', created_at: new Date() },
+      { id: 4, user_id: 2, coin_symbol: 'USDT', address: 'bob_usdt_addr', private_key: 'bob_usdt_pk', created_at: new Date() }
+    ], {});
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('wallets', null, {});
+  }
+};

--- a/backend/seeders/20250601000004-demo-transactions.js
+++ b/backend/seeders/20250601000004-demo-transactions.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('deposits', [
+      { id: 1, wallet_id: 1, tx_hash: 'deposit_tx1', amount: 0.5, confirmed: true, created_at: new Date() }
+    ], {});
+    await queryInterface.bulkInsert('withdrawals', [
+      { id: 1, wallet_id: 1, to_address: 'external_addr1', amount: 0.1, tx_hash: 'withdraw_tx1', status: 'CONFIRMED', created_at: new Date() }
+    ], {});
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('withdrawals', null, {});
+    await queryInterface.bulkDelete('deposits', null, {});
+  }
+};

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "server": "node server.js",
     "start:frontend": "cross-env NODE_OPTIONS=--openssl-legacy-provider PORT=3000 craco start",
     "start:backend": "cross-env PORT=3035 node server.js",
-    "dev": "concurrently \"npm run start:frontend\" \"npm run start:backend\""
+    "dev": "concurrently \"npm run start:frontend\" \"npm run start:backend\"",
+    "seed": "sequelize-cli db:seed:all"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Summary
- populate initial data with new seeders for coins, pairs, users, wallets and transactions
- add `npm run seed` helper script
- document how to run the seeds in the README

## Testing
- `npm test` *(fails: craco not found)*
- `npm run test:unit` *(fails: jest not found)*