### PR TITLE
Add environment template and scrub DB credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Example environment configuration
+
+# Database settings
+DB_USER=your_db_user
+DB_PASS=your_db_password
+DB_NAME=ubex
+DB_HOST=127.0.0.1
+
+# Server settings
+PORT=3035
+
+# Ethereum node
+WS_RPC_URL=ws://127.0.0.1:8545
+
+# Frontend API endpoint
+REACT_APP_API_URL=http://localhost:3035

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ yarn-error.log*
 
 *.log
 dist/
+mysqlconnect.ini

--- a/README.md
+++ b/README.md
@@ -18,12 +18,17 @@ cd ubex-exchange
 npm install
 ```
 
+3. Copy `.env.example` to `.env` and update the values
+```bash
+cp .env.example .env
+```
+
 ### Backend
 Run `npm run start:backend` (or `node server.js`) to launch the backend on port `3035`.
 If the backend is not running, the React frontend will encounter WebSocket and API timeout errors.
 
 ### Database
-The backend uses **MySQL** with Sequelize. Configure credentials via environment variables (`DB_USER`, `DB_PASS`, `DB_NAME`, `DB_HOST`) or edit `mysqlconnect.ini`.
+The backend uses **MySQL** with Sequelize. Configure credentials in the `.env` file (`DB_USER`, `DB_PASS`, `DB_NAME`, `DB_HOST`).
 Start MySQL before running the backend.
 
 ### Frontend

--- a/mysqlconnect.ini
+++ b/mysqlconnect.ini
@@ -1,9 +1,8 @@
-# MySQL 연결 정보
-DB_USER=mysql
-DB_PASS=mysql
+# MySQL connection template
+DB_USER=YOUR_DB_USER
+DB_PASS=YOUR_DB_PASS
 DB_NAME=ubex
 DB_HOST=127.0.0.1
 
-# 이더리움 노드 URL
-RPC_URL=https://mainnet.infura.io/v3/YOUR_INFURA_PROJECT_ID
-WS_RPC_URL=wss://mainnet.infura.io/ws/v3/YOUR_INFURA_PROJECT_ID
+# Ethereum node WebSocket URL
+WS_RPC_URL=ws://127.0.0.1:8545


### PR DESCRIPTION
## Summary
- scrub mysql credentials from `mysqlconnect.ini`
- add `mysqlconnect.ini` to `.gitignore`
- provide `.env.example` with required variables
- document setup of `.env` in the README

## Testing
- `npm run test:unit` *(fails: jest not found)*