### PR TITLE
Use env-based URLs

### DIFF
--- a/public/test-chart.html
+++ b/public/test-chart.html
@@ -100,7 +100,7 @@
 
   <script>
     // 서버 URL 설정
-    const SERVER_URL = 'http://localhost:3001';
+    const SERVER_URL = process.env.REACT_APP_API_URL || 'http://localhost:3035';
     
     // 소켓 연결
     const socket = io(SERVER_URL, {

--- a/recently_implemented.txt
+++ b/recently_implemented.txt
@@ -80,8 +80,8 @@ let socket = null;
 export const connectWebSocket = () => {
   if (!socket) {
     // 개발 환경에서는 localhost, 프로덕션에서는 실제 서버 주소로 변경
-    const SERVER_URL = window.location.hostname === 'localhost' 
-      ? 'http://localhost:3001' 
+    const SERVER_URL = window.location.hostname === 'localhost'
+      ? (process.env.REACT_APP_API_URL || 'http://localhost:3035')
       : window.location.origin;
     
     socket = io(SERVER_URL, {

--- a/server.js.backup
+++ b/server.js.backup
@@ -148,7 +148,7 @@ app.post('/api/register', async (req, res) => {
 });
 
 // 서버 시작
-const PORT = process.env.PORT || 3001;
+const PORT = process.env.PORT || 3035;
 server.listen(PORT, () => {
   console.log(`서버가 포트 ${PORT}에서 실행 중입니다`);
 });

--- a/src/services/MarketService.js
+++ b/src/services/MarketService.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_BASE_URL = 'http://localhost:3001/api';
+const API_BASE_URL = `${process.env.REACT_APP_API_URL || 'http://localhost:3035'}/api`;
 
 export const fetchTickerList = async () => {
   try {
@@ -14,7 +14,10 @@ export const fetchTickerList = async () => {
 };
 
 export const connectWebSocket = (symbols, onMessage) => {
-  const ws = new WebSocket('ws://localhost:3001/ws/ticker');
+  const baseUrl = process.env.REACT_APP_API_URL || 'http://localhost:3035';
+  const wsProtocol = baseUrl.startsWith('https') ? 'wss' : 'ws';
+  const wsUrl = baseUrl.replace(/^https?/, wsProtocol) + '/ws/ticker';
+  const ws = new WebSocket(wsUrl);
   ws.onopen = () => {
     ws.send(JSON.stringify({ type: 'subscribe', symbols }));
   };


### PR DESCRIPTION
## Summary
- use `REACT_APP_API_URL` with default `http://localhost:3035` in MarketService
- update WebSocket URL accordingly
- use the same env-based URL in public/test-chart.html
- update backup server port
- adjust documentation snippet

## Testing
- `npm test` *(fails: craco not found)*