### PR TITLE
Fix login credentials in registration

### DIFF
--- a/src/components/auth/Register.js
+++ b/src/components/auth/Register.js
@@ -50,7 +50,7 @@ const Register = () => {
       }
 
       const data = await response.json();
-      await login({ username: formData.username, password: formData.password });
+      await login({ email: formData.email, password: formData.password });
       navigate('/');
     } catch (error) {
       setError(error.message);


### PR DESCRIPTION
## Summary
- use `email` when logging in after registration

## Testing
- `npm test --silent` *(fails: craco not found)*