### PR TITLE
Add trade history endpoint

### DIFF
--- a/backend/controllers/tradeController.js
+++ b/backend/controllers/tradeController.js
@@ -47,3 +47,20 @@ exports.getUserOrders = async (req, res) => {
     res.status(500).json({ message: '오류 발생' });
   }
 };
+
+// 특정 심볼의 최근 체결 내역 조회
+exports.getTradeHistory = async (req, res) => {
+  const symbol = req.query.symbol;
+
+  if (!symbol) {
+    return res.status(400).json({ message: 'symbol parameter is required' });
+  }
+
+  try {
+    const trades = tradeEngine.getTradeHistory(symbol);
+    res.status(200).json(trades);
+  } catch (err) {
+    logger.error(`getTradeHistory error ${err.message}`);
+    res.status(500).json({ message: '오류 발생' });
+  }
+};

--- a/backend/routes/tradesRoutes.js
+++ b/backend/routes/tradesRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const tradeController = require('../controllers/tradeController');
+
+// 최근 체결 내역 조회
+router.get('/', tradeController.getTradeHistory);
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -38,6 +38,7 @@ db.sequelize.authenticate()
 const walletRoutes = require('./backend/routes/walletRoutes');
 const authRoutes = require('./backend/routes/authRoutes');
 const tradeRoutes = require('./backend/routes/tradeRoutes');
+const tradesRoutes = require('./backend/routes/tradesRoutes');
 const marketRoutes = require('./backend/routes/marketRoutes');
 const apiKeyRoutes = require('./backend/routes/apiKeyRoutes');
 const adminCoinRoutes = require('./backend/routes/adminCoinRoutes');
@@ -54,6 +55,7 @@ app.use('/api/v1/wallet', walletRoutes);
 app.use('/api/auth', authRoutes);  // /api/auth 경로로 수정
 app.use('/auth', authRoutes);      // 기존 /auth 경로도 유지
 app.use('/api/orders', tradeRoutes);
+app.use('/api/trades', tradesRoutes);
 app.use('/api/markets', marketRoutes);
 app.use('/api/keys', apiKeyRoutes);
 app.use('/api/admin', adminAuthRoutes);

--- a/src/services/tradeService.js
+++ b/src/services/tradeService.js
@@ -126,7 +126,8 @@ export const getOrderBook = async (symbol) => {
 
 export const getRecentTrades = async (symbol) => {
   try {
-    const response = await api.get(`/trades/${symbol}`);
+    const query = encodeURIComponent(symbol);
+    const response = await api.get(`/trades?symbol=${query}`);
     return response.data;
   } catch (error) {
     console.error('최근 체결 내역 조회 서비스 실패:', error.message);


### PR DESCRIPTION
## Summary
- implement `getTradeHistory` controller
- add `tradesRoutes` and mount it
- support trade history requests from frontend

## Testing
- `npm run test:unit` *(fails: jest not found)*