### PR TITLE
Handle empty candles data

### DIFF
--- a/src/components/Chart/SimpleChart.js
+++ b/src/components/Chart/SimpleChart.js
@@ -224,7 +224,11 @@ const SimpleChart = ({
     };
 
     const handleCandles = (data) => {
-      processInitialData(data);
+      if (!data || data.length === 0) {
+        processInitialData(generateDummyData());
+      } else {
+        processInitialData(data);
+      }
     };
 
     const handleCandlestick = (data) => {


### PR DESCRIPTION
## Summary
- avoid showing empty chart when no candle data is returned

## Testing
- `npm test` *(fails: craco not found)*