### PR TITLE
Add frontend deposit address setter

### DIFF
--- a/src/components/Wallet/DepositForm.jsx
+++ b/src/components/Wallet/DepositForm.jsx
@@ -1,19 +1,22 @@
 // src/components/Wallet/DepositForm.jsx
 import React, { useState, useEffect } from 'react';
-import { getDepositAddress } from '../../services/WalletService';
+import { getDepositAddress, setDepositAddress } from '../../services/WalletService';
 import './Wallet.css';
 
-const DepositForm = ({ currency }) => {
+const DepositForm = ({ coin, currency }) => {
+  const coinSymbol = coin || currency;
   const [address, setAddress] = useState('');
+  const [inputAddress, setInputAddress] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(false);
 
   useEffect(() => {
     const fetchDepositAddress = async () => {
       try {
         setLoading(true);
         setError(null);
-        const depositAddress = await getDepositAddress(currency);
+        const depositAddress = await getDepositAddress(coinSymbol);
         setAddress(depositAddress);
       } catch (error) {
         console.error('입금주소 조회 실패', error);
@@ -26,7 +29,24 @@ const DepositForm = ({ currency }) => {
     };
 
     fetchDepositAddress();
-  }, [currency]);
+  }, [coinSymbol]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      setError(null);
+      setSuccess(false);
+      await setDepositAddress(coinSymbol, { address: inputAddress });
+      setAddress(inputAddress);
+      setInputAddress('');
+      setSuccess(true);
+    } catch (error) {
+      console.error('입금주소 설정 실패', error);
+      if (process.env.REACT_APP_USE_DUMMY_DATA !== 'true') {
+        setError('입금 주소 설정에 실패했습니다.');
+      }
+    }
+  };
 
   if (loading) {
     return <div className="wallet-loading">Loading...</div>;
@@ -38,7 +58,8 @@ const DepositForm = ({ currency }) => {
 
   return (
     <div className="deposit-form">
-      <h3>{currency} 입금</h3>
+      <h3>{coinSymbol} 입금</h3>
+      {success && <div className="wallet-success">주소가 저장되었습니다.</div>}
       <div className="deposit-address">
         <p>입금 주소:</p>
         <div className="address-container">
@@ -53,10 +74,23 @@ const DepositForm = ({ currency }) => {
           </button>
         </div>
       </div>
+      <form onSubmit={handleSubmit} className="form-group">
+        <label>입금 주소 설정</label>
+        <input
+          type="text"
+          value={inputAddress}
+          onChange={(e) => setInputAddress(e.target.value)}
+          placeholder="입금 주소를 입력하세요"
+          required
+        />
+        <button type="submit" className="submit-button">
+          저장
+        </button>
+      </form>
       <div className="deposit-info">
         <p>※ 주의사항:</p>
         <ul>
-          <li>입금 주소는 {currency} 전용 주소입니다.</li>
+          <li>입금 주소는 {coinSymbol} 전용 주소입니다.</li>
           <li>다른 코인을 입금하면 자산이 손실될 수 있습니다.</li>
           <li>입금 후 네트워크 확인에 따라 최대 30분까지 소요될 수 있습니다.</li>
         </ul>

--- a/src/services/WalletService.js
+++ b/src/services/WalletService.js
@@ -82,6 +82,23 @@ export const getDepositAddress = async (currency) => {
 };
 
 /**
+ * 사용자가 직접 입금 주소를 설정
+ */
+export const setDepositAddress = async (currency, data) => {
+  if (process.env.REACT_APP_USE_DUMMY_DATA === 'true') {
+    return { success: true };
+  }
+
+  try {
+    const response = await api.post(`/wallet/deposit-address/${currency}`, data);
+    return response.data;
+  } catch (error) {
+    console.error('입금주소 설정 실패', error);
+    throw error;
+  }
+};
+
+/**
  * 화이트리스트 조회/등록/삭제
  */
 export const listWhitelist = async (currency) => {


### PR DESCRIPTION
## Summary
- allow users to set deposit address in UI
- support POST `/wallet/deposit-address/:coin` via new service

## Testing
- `npm run test:unit` *(fails: jest not found)*