### PR TITLE
Implement whitelist rate limit middleware

### DIFF
--- a/backend/middlewares/whitelistRateLimit.js
+++ b/backend/middlewares/whitelistRateLimit.js
@@ -1,0 +1,52 @@
+const ipAttempts = new Map();
+const userAttempts = new Map();
+
+function whitelistRateLimit(req, res, next) {
+  const now = Date.now();
+  const ip = req.ip;
+  const userId = req.user && req.user.id;
+
+  // IP limit: 10 attempts per hour
+  let ipData = ipAttempts.get(ip);
+  if (!ipData) {
+    ipData = { count: 0, lastReset: now };
+    ipAttempts.set(ip, ipData);
+  }
+  if (now - ipData.lastReset >= 60 * 60 * 1000) {
+    ipData.count = 0;
+    ipData.lastReset = now;
+  }
+  if (ipData.count >= 10) {
+    return res.status(429).json({
+      success: false,
+      message: 'IP당 시간당 최대 10회 시도만 허용됩니다.'
+    });
+  }
+  ipData.count += 1;
+
+  // User limit: 5 registrations per day
+  let userData = userAttempts.get(userId);
+  if (!userData) {
+    userData = { count: 0, lastReset: now };
+    userAttempts.set(userId, userData);
+  }
+  if (now - userData.lastReset >= 24 * 60 * 60 * 1000) {
+    userData.count = 0;
+    userData.lastReset = now;
+  }
+  if (userData.count >= 5) {
+    return res.status(429).json({
+      success: false,
+      message: '하루 최대 5회의 화이트리스트 등록만 허용됩니다.'
+    });
+  }
+  userData.count += 1;
+  next();
+}
+
+whitelistRateLimit.reset = function () {
+  ipAttempts.clear();
+  userAttempts.clear();
+};
+
+module.exports = whitelistRateLimit;

--- a/backend/routes/walletRoutes.js
+++ b/backend/routes/walletRoutes.js
@@ -15,6 +15,7 @@ const {
   deleteWhitelist // 화이트리스트 관리
 } = require('../controllers/walletController');
 const authMiddleware = require('../middlewares/authMiddleware');
+const whitelistRateLimit = require('../middlewares/whitelistRateLimit');
 // const { validateWithdraw } = require('../middlewares/validation'); // 유효성 검사 미들웨어 (추후 구현 시 사용)
 
 // GET /api/wallet/deposit-address/:coin - 입금 주소 조회
@@ -41,7 +42,12 @@ router.get('/balances', authMiddleware, getUserBalances);
 
 // 화이트리스트 관리
 router.get('/:coin/whitelist', authMiddleware, listWhitelist);
-router.post('/:coin/whitelist', authMiddleware, addWhitelist);
+router.post(
+  '/:coin/whitelist',
+  authMiddleware,
+  whitelistRateLimit,
+  addWhitelist
+);
 router.delete('/:coin/whitelist/:id', authMiddleware, deleteWhitelist);
 
 module.exports = router;

--- a/test/unit/whitelistRateLimit.test.js
+++ b/test/unit/whitelistRateLimit.test.js
@@ -1,0 +1,44 @@
+const whitelistRateLimit = require('../../backend/middlewares/whitelistRateLimit');
+
+describe('whitelistRateLimit middleware', () => {
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    whitelistRateLimit.reset();
+    req = { user: { id: 1 }, ip: '1.1.1.1' };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    next = jest.fn();
+  });
+
+  test('allows up to 5 registrations per user per day', () => {
+    for (let i = 0; i < 5; i++) {
+      whitelistRateLimit(req, res, next);
+    }
+    expect(next).toHaveBeenCalledTimes(5);
+
+    whitelistRateLimit(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(res.json).toHaveBeenCalled();
+  });
+
+  test('limits 10 attempts per IP per hour', () => {
+    for (let i = 0; i < 10; i++) {
+      req.user.id = i;
+      whitelistRateLimit(req, res, next);
+    }
+    expect(next).toHaveBeenCalledTimes(10);
+
+    res.status.mockClear();
+    res.json.mockClear();
+    next.mockClear();
+    req.user.id = 999;
+    whitelistRateLimit(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(res.json).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add middleware to enforce rate limits for whitelist registrations
- apply middleware to wallet whitelist POST route
- test user/day and ip/hour limits

## Testing
- `npm run test:unit` *(fails: jest not found)*