### PR TITLE
Add whitelist confirmation check on withdrawals

### DIFF
--- a/backend/controllers/walletController.js
+++ b/backend/controllers/walletController.js
@@ -46,6 +46,7 @@ let userWallets = {
   // DB 및 블록체인 서비스 불러오기
   const db = require('../models');
   const blockchainService = require('../services/blockchainService')();
+  const { checkWhitelistAddress } = require('../helpers/whitelistHelper');
 
   // 입금 주소 조회 로직
 exports.getDepositAddress = async (req, res) => {
@@ -155,16 +156,21 @@ exports.setDepositAddress = async (req, res) => {
         return res.status(400).json({ success: false, message: `${coinSymbol} 출금 가능 잔액이 부족합니다. (보유: ${availableBalance})` });
       }
   
-      // 실제 출금 처리 로직 (블록체인 트랜잭션 생성 및 DB 기록)
-      userWallets[userId][coinSymbol].available -= withdrawalAmount;
-      userWallets[userId][coinSymbol].total -= withdrawalAmount; // total도 함께 차감
-
       const wallet = await db.Wallet.findOne({
         where: { user_id: userId, coin_symbol: coinSymbol }
       });
       if (!wallet) {
         return res.status(400).json({ success: false, message: `${coinSymbol} 지갑이 존재하지 않습니다.` });
       }
+
+      const allowed = await checkWhitelistAddress(userId, coinSymbol, address);
+      if (!allowed) {
+        return res.status(400).json({ success: false, message: '등록된 출금 주소가 아닙니다.' });
+      }
+
+      // 실제 출금 처리 로직 (블록체인 트랜잭션 생성 및 DB 기록)
+      userWallets[userId][coinSymbol].available -= withdrawalAmount;
+      userWallets[userId][coinSymbol].total -= withdrawalAmount; // total도 함께 차감
 
       const tx = await blockchainService.sendTransaction(
         coinSymbol,

--- a/backend/helpers/whitelistHelper.js
+++ b/backend/helpers/whitelistHelper.js
@@ -1,0 +1,17 @@
+const db = require('../models');
+
+/**
+ * 확인된 화이트리스트 주소인지 검사
+ * @param {number} userId
+ * @param {string} coinSymbol
+ * @param {string} address
+ * @returns {Promise<boolean>}
+ */
+async function checkWhitelistAddress(userId, coinSymbol, address) {
+  const entry = await db.WhitelistAddress.findOne({
+    where: { user_id: userId, coin_symbol: coinSymbol, address }
+  });
+  return !!(entry && entry.confirmed);
+}
+
+module.exports = { checkWhitelistAddress };

--- a/backend/models/whitelist_address.js
+++ b/backend/models/whitelist_address.js
@@ -6,7 +6,8 @@ module.exports = (sequelize, DataTypes) => {
     user_id:     { type: DataTypes.BIGINT, allowNull: false },
     coin_symbol: { type: DataTypes.STRING(10), allowNull: false },
     address:     { type: DataTypes.STRING(128), allowNull: false },
-    label:       { type: DataTypes.STRING(50) }
+    label:       { type: DataTypes.STRING(50) },
+    confirmed:   { type: DataTypes.BOOLEAN, defaultValue: false }
   }, {
     tableName: 'whitelist_addresses',
     timestamps: true,

--- a/test/unit/walletController.test.js
+++ b/test/unit/walletController.test.js
@@ -1,0 +1,77 @@
+jest.mock('../../backend/helpers/whitelistHelper', () => ({
+  checkWhitelistAddress: jest.fn()
+}));
+jest.mock('../../backend/models', () => ({
+  Wallet: { findOne: jest.fn() },
+  Withdrawal: { create: jest.fn() },
+  WhitelistAddress: { findOne: jest.fn() }
+}));
+const mockSendTransaction = jest.fn();
+jest.mock('../../backend/services/blockchainService', () => {
+  const svc = jest.fn(() => ({ sendTransaction: mockSendTransaction }));
+  svc.mockSendTransaction = mockSendTransaction;
+  return svc;
+});
+
+let requestWithdrawal;
+let db;
+let blockchainService;
+let checkWhitelistAddress;
+
+describe('requestWithdrawal whitelist check', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    ({ checkWhitelistAddress } = require('../../backend/helpers/whitelistHelper'));
+    db = require('../../backend/models');
+    blockchainService = require('../../backend/services/blockchainService');
+    ({ requestWithdrawal } = require('../../backend/controllers/walletController'));
+  });
+
+  function createReq(amount = 0.1) {
+    return {
+      body: { coin: 'BTC', amount, address: 'DEST' },
+      user: { id: 1 },
+      app: { get: () => 3035 }
+    };
+  }
+
+  test('fails when address not confirmed', async () => {
+    checkWhitelistAddress.mockResolvedValue(false);
+    db.Wallet.findOne.mockResolvedValue({ id: 1, address: 'FROM' });
+    const req = createReq();
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await requestWithdrawal(req, res);
+
+    expect(checkWhitelistAddress).toHaveBeenCalledWith(1, 'BTC', 'DEST');
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ success: false, message: '등록된 출금 주소가 아닙니다.' });
+    expect(blockchainService.mockSendTransaction).not.toHaveBeenCalled();
+    expect(db.Withdrawal.create).not.toHaveBeenCalled();
+  });
+
+  test('succeeds when address confirmed', async () => {
+    checkWhitelistAddress.mockResolvedValue(true);
+    db.Wallet.findOne.mockResolvedValue({ id: 1, address: 'FROM' });
+    blockchainService.mockSendTransaction.mockResolvedValue({ txHash: 'hash' });
+    db.Withdrawal.create.mockResolvedValue({
+      id: 1,
+      wallet_id: 1,
+      to_address: 'DEST',
+      amount: 0.1,
+      tx_hash: 'hash',
+      status: 'PENDING',
+      created_at: new Date()
+    });
+
+    const req = createReq();
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await requestWithdrawal(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(db.Withdrawal.create).toHaveBeenCalled();
+    expect(res.json.mock.calls[0][0].success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `confirmed` field to WhitelistAddress model
- add helper to verify whitelisted addresses
- enforce whitelist check in withdrawal endpoint
- unit tests for withdrawal whitelist logic

## Testing
- `npx jest` *(fails: jest not found)*