### PR TITLE
Add coverage tests for wallet and auth flows

### DIFF
--- a/test/integration/registerWithdraw.test.js
+++ b/test/integration/registerWithdraw.test.js
@@ -1,0 +1,57 @@
+jest.mock('../../backend/models', () => ({
+  User: {
+    findOne: jest.fn(),
+    create: jest.fn(),
+  },
+  Wallet: {
+    findOne: jest.fn(),
+    create: jest.fn(),
+  },
+  Withdrawal: {
+    create: jest.fn(),
+  },
+}));
+
+jest.mock('../../backend/services/blockchainService', () => () => ({
+  generateAddress: jest.fn().mockResolvedValue({ address: 'addr1', privateKey: 'pk1' }),
+  sendTransaction: jest.fn().mockResolvedValue({ txHash: 'tx123' }),
+}));
+
+const jwt = require('jsonwebtoken');
+const jwtConfig = require('../../backend/config/jwtConfig');
+const authController = require('../../backend/controllers/authController');
+const walletController = require('../../backend/controllers/walletController');
+const db = require('../../backend/models');
+
+const createRes = () => ({ status: jest.fn().mockReturnThis(), json: jest.fn() });
+
+describe('registration to withdrawal flow', () => {
+  test('user can register and withdraw', async () => {
+    db.User.findOne.mockResolvedValue(null);
+    db.User.create.mockResolvedValue({
+      id: 1,
+      username: 'test',
+      email: 'test@example.com',
+      password: 'hashed',
+      toJSON() { return { id: 1, username: 'test', email: 'test@example.com' }; },
+    });
+    db.Wallet.findOne.mockResolvedValue({ id: 1, user_id: 1, coin_symbol: 'BTC', address: 'addr1', private_key: 'pk1' });
+    db.Withdrawal.create.mockResolvedValue({ id: 1, wallet_id: 1, amount: 0.1, tx_hash: 'tx123', status: 'PENDING', created_at: new Date() });
+
+    const reqReg = { body: { username: 'test', email: 'test@example.com', password: 'pass' } };
+    const resReg = createRes();
+    await authController.register(reqReg, resReg);
+    expect(resReg.status).toHaveBeenCalledWith(201);
+    const token = resReg.json.mock.calls[0][0].token;
+    const userId = jwt.verify(token, jwtConfig.secret).userId;
+
+    const reqWithdraw = {
+      body: { coin: 'BTC', amount: 0.1, address: 'destAddr' },
+      user: { id: userId },
+      app: { get: () => 3035 },
+    };
+    const resWithdraw = createRes();
+    await walletController.requestWithdrawal(reqWithdraw, resWithdraw);
+    expect(resWithdraw.status).toHaveBeenCalledWith(201);
+  });
+});

--- a/test/unit/addressValidation.test.js
+++ b/test/unit/addressValidation.test.js
@@ -1,0 +1,24 @@
+const walletController = require('../../backend/controllers/walletController');
+
+// Mock response object
+const createRes = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn(),
+});
+
+describe('setDepositAddress validation', () => {
+  test('returns 400 when address missing', async () => {
+    const req = {
+      params: { coin: 'BTC' },
+      body: { address: '' },
+      user: { id: 1 },
+      app: { get: () => 3035 },
+    };
+    const res = createRes();
+
+    await walletController.setDepositAddress(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ success: false, message: '주소가 필요합니다.' });
+  });
+});

--- a/test/unit/duplicateEmail.test.js
+++ b/test/unit/duplicateEmail.test.js
@@ -1,0 +1,24 @@
+jest.mock('../../backend/models', () => ({
+  User: {
+    findOne: jest.fn(),
+    create: jest.fn(),
+  },
+}));
+
+const authController = require('../../backend/controllers/authController');
+const db = require('../../backend/models');
+
+const createRes = () => ({ status: jest.fn().mockReturnThis(), json: jest.fn() });
+
+describe('register duplicate email', () => {
+  test('returns 400 when email already exists', async () => {
+    db.User.findOne.mockResolvedValue({ id: 1 });
+
+    const req = { body: { username: 'u', email: 'e@test.com', password: 'p' } };
+    const res = createRes();
+    await authController.register(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ success: false, message: '이미 등록된 이메일입니다.' });
+  });
+});

--- a/test/unit/rateLimit.test.js
+++ b/test/unit/rateLimit.test.js
@@ -1,0 +1,10 @@
+jest.mock('axios');
+const axios = require('axios');
+const apiService = require('../../backend/services/ExternalApiService');
+
+describe('ExternalApiService rate limit', () => {
+  test('propagates 429 error', async () => {
+    axios.get.mockRejectedValue({ response: { status: 429 } });
+    await expect(apiService.fetchBinanceTicker('BTCUSDT')).rejects.toHaveProperty('response.status', 429);
+  });
+});

--- a/test/unit/securityService.test.js
+++ b/test/unit/securityService.test.js
@@ -1,0 +1,13 @@
+const createSecurityService = require('../../backend/services/securityService');
+
+describe('securityService token', () => {
+  test('setup and verify 2FA token', async () => {
+    const security = createSecurityService();
+    const { secret, status } = await security.setup2FA(1);
+    expect(secret).toBeDefined();
+    expect(status).toBe('pending_verification');
+
+    const result = await security.verify2FA(1, '123456');
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for wallet address validation
- add unit test to prevent duplicate registration
- test 2FA token setup/verification
- handle API rate limit errors
- integration test covering registration to withdrawal flow

## Testing
- `npm run test:unit` *(fails: jest not found)*