### PR TITLE
Fix wallet service return handling

### DIFF
--- a/src/pages/WhitelistAddressesPage.jsx
+++ b/src/pages/WhitelistAddressesPage.jsx
@@ -18,7 +18,7 @@ export default function WhitelistAddressesPage() {
       setLoading(true);
       setError(null);
       const data = await getWhitelistAddresses();
-      setAddresses(data.data || data);
+      setAddresses(data);
     } catch (err) {
       console.error(err);
       setError('화이트리스트를 불러오는데 실패했습니다.');

--- a/src/services/WalletService.js
+++ b/src/services/WalletService.js
@@ -74,7 +74,7 @@ export const getDepositAddress = async (currency) => {
 
   try {
     const response = await api.get(`/wallet/deposit-address/${currency}`);
-    return response.data.address;
+    return response.data.data.address;
   } catch (error) {
     console.error('입금주소 조회 실패', error);
     throw error;
@@ -108,7 +108,7 @@ export const listWhitelist = async (currency) => {
 
   try {
     const response = await api.get(`/wallet/whitelist-addresses/${currency}`);
-    return response.data;
+    return response.data.data;
   } catch (error) {
     console.error('화이트리스트 조회 실패', error);
     throw error;
@@ -179,7 +179,7 @@ export const getWhitelistAddresses = async () => {
 
   try {
     const response = await api.get('/wallet/whitelist-addresses');
-    return response.data;
+    return response.data.data;
   } catch (error) {
     console.error('화이트리스트 전체 조회 실패', error);
     throw error;


### PR DESCRIPTION
## Summary
- update `getDepositAddress` to extract `data.address`
- update `listWhitelist` and `getWhitelistAddresses` to return `response.data.data`
- adjust whitelist page to use the new return shape

## Testing
- `npm test --silent` *(fails: craco not found)*
- `npm run test:unit --silent` *(fails: jest not found)*