### PR TITLE
Update default coin

### DIFF
--- a/src/pages/WalletPage.jsx
+++ b/src/pages/WalletPage.jsx
@@ -6,7 +6,7 @@ import WithdrawForm from '../components/Wallet/WithdrawForm.jsx';
 export default function WalletPage() {
   // URL에 /wallet/:coin 형태로 coin 파라미터 사용
   const { coin } = useParams();
-  const defaultCoin = 'BTC'; // 기본 코인 설정
+  const defaultCoin = 'ETH'; // 기본 코인 설정
 
   return (
     <div className="wallet-layout">


### PR DESCRIPTION
## Summary
- default withdraw coin is now ETH on WalletPage

## Testing
- `npm test` *(fails: craco not found)*