### PR TITLE
Update balance after deposit events

### DIFF
--- a/backend/controllers/walletController.js
+++ b/backend/controllers/walletController.js
@@ -19,47 +19,14 @@ const checkRateLimit = (userId) => {
   return true;
 };
 
-// 임시 사용자 잔액 저장소 (서버 재시작 시 초기화됨)
-// userId: { BTC: { available: 1, inOrder: 0.1, total: 1.1 }, ETH: { ... }, KRW: { ... } } 형태
-// 기본 데모 코인 잔액 (테스트용 시드 데이터)
-let userWallets = {
-    1: { // 예시: test@example.com 사용자의 ID가 1이라고 가정
-      BTC:   { available: 0.5,    inOrder: 0, total: 0.5 },
-      ETH:   { available: 5,      inOrder: 0, total: 5 },
-      XRP:   { available: 1000,   inOrder: 0, total: 1000 },
-      ADA:   { available: 2000,   inOrder: 0, total: 2000 },
-      DOT:   { available: 300,    inOrder: 0, total: 300 },
-      LAYER: { available: 5000,   inOrder: 0, total: 5000 },
-      KAITO: { available: 5000,   inOrder: 0, total: 5000 },
-      STPT:  { available: 10000,  inOrder: 0, total: 10000 },
-      MOVE:  { available: 5000,   inOrder: 0, total: 5000 },
-      USDT:  { available: 1000,   inOrder: 0, total: 1000 },
-      KRW:   { available: 5000000, inOrder: 0, total: 5000000 }
-    },
-    2: { // 예시: fff@gmail.com 사용자의 ID가 2이라고 가정
-      BTC: { available: 0.1, inOrder: 0, total: 0.1 },
-      ETH: { available: 2, inOrder: 0, total: 2 },
-      USDT: { available: 500, inOrder: 0, total: 500 },
-      KRW: { available: 1000000, inOrder: 0, total: 1000000 }
-    },
-  };
-  
+// 임시 사용자 잔액 저장소는 서비스 모듈에서 관리한다
+const { userWallets, ensureUserWallet } = require('../services/balanceStore');
+
   // 임시 입출금 내역 저장소
   let transactionHistory = [];
   let nextTransactionId = 1;
   
-  // Helper function to ensure user wallet exists
-  const demoCoins = ['BTC', 'ETH', 'XRP', 'ADA', 'DOT', 'LAYER', 'KAITO', 'STPT', 'MOVE', 'USDT', 'KRW'];
-  const ensureUserWallet = (userId) => {
-    if (!userWallets[userId]) {
-      userWallets[userId] = {};
-    }
-    demoCoins.forEach(sym => {
-      if (!userWallets[userId][sym]) {
-        userWallets[userId][sym] = { available: 0, inOrder: 0, total: 0 };
-      }
-    });
-  };
+  // Helper function to ensure user wallet exists is provided by balanceStore
   
   
   // DB 및 블록체인 서비스 불러오기

--- a/backend/services/balanceStore.js
+++ b/backend/services/balanceStore.js
@@ -1,0 +1,44 @@
+// backend/services/balanceStore.js
+// Simple in-memory wallet balance store used by walletController and blockchainListener
+
+const demoCoins = ['BTC', 'ETH', 'XRP', 'ADA', 'DOT', 'LAYER', 'KAITO', 'STPT', 'MOVE', 'USDT', 'KRW'];
+
+// 초기 데모 잔액 (테스트용)
+const userWallets = {
+  1: {
+    BTC:   { available: 0.5,    inOrder: 0, total: 0.5 },
+    ETH:   { available: 5,      inOrder: 0, total: 5 },
+    XRP:   { available: 1000,   inOrder: 0, total: 1000 },
+    ADA:   { available: 2000,   inOrder: 0, total: 2000 },
+    DOT:   { available: 300,    inOrder: 0, total: 300 },
+    LAYER: { available: 5000,   inOrder: 0, total: 5000 },
+    KAITO: { available: 5000,   inOrder: 0, total: 5000 },
+    STPT:  { available: 10000,  inOrder: 0, total: 10000 },
+    MOVE:  { available: 5000,   inOrder: 0, total: 5000 },
+    USDT:  { available: 1000,   inOrder: 0, total: 1000 },
+    KRW:   { available: 5000000, inOrder: 0, total: 5000000 }
+  },
+  2: {
+    BTC: { available: 0.1, inOrder: 0, total: 0.1 },
+    ETH: { available: 2,   inOrder: 0, total: 2 },
+    USDT:{ available: 500, inOrder: 0, total: 500 },
+    KRW: { available: 1000000, inOrder: 0, total: 1000000 }
+  }
+};
+
+function ensureUserWallet(userId) {
+  if (!userWallets[userId]) {
+    userWallets[userId] = {};
+  }
+  demoCoins.forEach(sym => {
+    if (!userWallets[userId][sym]) {
+      userWallets[userId][sym] = { available: 0, inOrder: 0, total: 0 };
+    }
+  });
+}
+
+module.exports = {
+  userWallets,
+  ensureUserWallet,
+  demoCoins
+};

--- a/backend/services/blockchainListener.js
+++ b/backend/services/blockchainListener.js
@@ -2,6 +2,7 @@
 'use strict';
 const Web3 = require('web3');           // v1.x 설치 후
 const db   = require('../models');
+const { userWallets, ensureUserWallet } = require('./balanceStore');
 
 module.exports.startListening = () => {
   const wsUrl   = process.env.WS_RPC_URL || 'ws://127.0.0.1:8545';
@@ -14,13 +15,23 @@ module.exports.startListening = () => {
     for (const tx of block.transactions || []) {
       const wallet = await db.Wallet.findOne({ where: { address: tx.to } });
       if (wallet) {
+        const amountStr = web3.utils.fromWei(tx.value, 'ether');
         await db.Deposit.create({
           wallet_id: wallet.id,
           tx_hash:   tx.hash,
-          amount:    web3.utils.fromWei(tx.value, 'ether'),
+          amount:    amountStr,
           confirmed: false
         });
-        console.log(`[Deposit] ${tx.to} ← ${tx.hash}`);
+
+        const userId = wallet.user_id;
+        const coinSymbol = wallet.coin_symbol;
+        ensureUserWallet(userId);
+        const amount = parseFloat(amountStr);
+        userWallets[userId][coinSymbol].available += amount;
+        userWallets[userId][coinSymbol].total += amount;
+        // TODO: Persist balances to DB if persistent storage is added
+        console.log(`[Deposit] ${tx.to} ← ${tx.hash} (${amountStr} ${coinSymbol})`);
+        console.log('[Deposit] Updated balance:', userWallets[userId][coinSymbol]);
       }
     }
   })


### PR DESCRIPTION
## Summary
- share in-memory balance data via new `balanceStore`
- update balances when blockchain listener detects deposit
- use shared store in wallet controller

## Testing
- `npm test` *(fails: craco not found)*
- `npm run test:unit` *(fails: jest not found)*